### PR TITLE
Add references to Tailwind CSS and dev vs. prod static files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
-You may use this Custom-Django Template I made, which is simplified, and I found efficient when handling you're own API's. 
+You may use this Custom-Django Template I made, which is simplified, and I found efficient when handling you're own API's.
 
 all goods as initial & has admin (currently hidden)
+
+References:
+
+Tailwind CSS + Django Best Documentation, https://www.youtube.com/watch?v=lsQVukhwpqQ
+dev vs. prod static files, https://www.youtube.com/watch?v=QTb5fK1SiFU and https://www.youtube.com/watch?v=AeCZvXZn5dg


### PR DESCRIPTION
This pull request adds references to Tailwind CSS and dev vs. prod static files in the README file. These references provide helpful resources for developers who want to use Tailwind CSS and learn about the differences between development and production static files.

References:

- Tailwind CSS + Django Best Documentation, https://www.youtube.com/watch?v=lsQVukhwpqQ

- dev vs. prod static files, https://www.youtube.com/watch?v=QTb5fK1SiFU and https://www.youtube.com/watch?v=AeCZvXZn5dg