### PR TITLE
Make styles and scripts production-ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,6 @@ cython_debug/
 # mar
 *-cdn*
 *.txt
+*.Identifier
 /.vscode
 /node_modules
-*.Identifier

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@ You may use this Custom-Django Template I made, which is simplified, and I found
 
 all goods as initial & has admin (currently hidden)
 
+to use the template:
+1. you need a database inside:
+application/_core/database/["db.sqlite3]
+2. you need to have `.env` just outside the application folder
+where it should contains:
+APP_NAME=app_name
+SECRET_KEY=secret_key
+ALLOWED_HOSTS=str localhost 127.0.0.1
+DEBUG=True or False
+DATABASE_URL=""
+
 
 
 

--- a/application/_core/settings.py
+++ b/application/_core/settings.py
@@ -5,11 +5,18 @@
 
 import os
 from pathlib import Path
+from dotenv import load_dotenv as env_load
 
+# Load environment variables
+env_load()
+
+# Mar - using the .env file
 BASE_DIR = Path(__file__).resolve().parent.parent
-SECRET_KEY = "django-insecure-^q#4_h0(o^k@rawy*2=e0uv78xy%ys5!)g73lpq(_-@@429!)b"
-DEBUG = True
-ALLOWED_HOSTS = ["*"]
+SECRET_KEY = os.getenv("SECRET_KEY", "default_secret_key")
+DEBUG = os.getenv("DEBUG", "False").lower() == "true"
+
+# separate the hosts with a space
+ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS").split(" ")
 
 # Open the settings.py file and look for the INSTALLED_APPS list
 INSTALLED_APPS = [
@@ -18,6 +25,8 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    # Mar: For production, we use whitenoice, just above static
+    "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     # Mar: Apps here - Internal
     "django_htmx",
@@ -28,6 +37,8 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    # Mar: For production, we use whitenoice, just above security
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -100,6 +111,9 @@ STATICFILES_DIRS = [
 # for tailwind css local [for use of the python manage.py collectstatic]
 # in production, we need a cdn files (contents delivery network)
 STATIC_ROOT = BASE_DIR.parent / "production-cdn" / "static"
+
+# Mar: for whitenoise storage
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 asgiref==3.7.2
-Django==3.2.23
+Django==3.2.19
 django-htmx==1.17.0
 gunicorn==20.1.0
+python-dotenv==1.0.0
 pytz==2023.3.post1
 sqlparse==0.4.4
 typing_extensions==4.8.0
 tzdata==2023.3
+whitenoise==6.6.0


### PR DESCRIPTION
This pull request includes changes to make the styles and scripts files production-ready. It updates the .gitignore file to exclude *.Identifier files, adds a custom Django template, and loads environment variables from a .env file. It also adds the whitenoise package for production use and updates the Django version to 3.2.19. Finally, it updates the requirements.txt file to include the necessary packages.

Fixes #6